### PR TITLE
Remove color settings from vscode's settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -122,19 +122,5 @@
         "execution": "cpp"
     },
     "C_Cpp.errorSquiggles": "Disabled",
-    "C_Cpp.dimInactiveRegions": false,
-    "workbench.colorCustomizations": {
-        "editorCursor.foreground":    "#ffaa00",
-        "editorCursor.background":    "#ff8800",
-        "editor.selectionBackground": "#0000cc",
-        "editor.selectionForeground": "#ffffff",
-        "activityBar.background":     "#132053",
-        "activityBar.foreground":     "#ffffff",
-        "activityBar.activeBorder":   "#4c9fdf",
-        "titleBar.activeBackground":  "#223344",
-        "titleBar.activeForeground":  "#FEFBF7",
-        "editor.background":          "#1a1f1f",
-        "menu.background":            "#333355",
-        "sideBar.background":         "#202038"
-    }
+    "C_Cpp.dimInactiveRegions": false
 }


### PR DESCRIPTION
Those colors in there fook with any colorscheme which isnt dark, and quite a bit of dark themes look weird with those hard coded values...

here an example

![image](https://github.com/tksuoran/erhe/assets/15695435/ca29714a-eef2-4111-ae51-a27f1fcbf863)
